### PR TITLE
Update to match with new cblrepo (v0.18.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Please have a look at using the Nix package manager which handles things in a mu
 # cabal2pkgbuild
 
 `cabal2pkgbuild` is a script used to generate proper PKGBUILD files from any `.cabal` file from Hackage, with the help of `cblrepo` (which is currently used to maintain Haskell packages on Arch Linux).
-`aria2` is used to download cabal files in parallel.
 
 ## Installation
 
@@ -17,7 +16,6 @@ This script is available on the [AUR](https://aur.archlinux.org/packages/cabal2p
 These are the following dependencies on Arch Linux:
 
 - cblrepo
-- aria2
 - coreutils
 - grep
 - pacman

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Refer to the [cblrepo](https://github.com/magthe/cblrepo) documentation for furt
 
 ### Database Generation, PKGBUILD Creation, and Package Installation
 
-Go into `my-haskell-packages`, and create a file listing all Hackage packages, one on each line, that you'd like to create PKGBUIKLDs for.
+Go into `my-haskell-packages`, and create a file listing all Hackage packages, one on each line, that you'd like to create PKGBUIKLDs for. Optionally you can specify an explicit version through comma (`','`). So format of each line is `<package-name>[,<package-version>]`.
 This is called the `<hackage_packages_file>` file by convention.
 
 The following is a sample `<hackage_pacakges_file>` file:
@@ -51,7 +51,7 @@ bindings-GLFW
 GLFW-b
 transformers-compat
 contravariant
-distributive
+distributive,0.4.3.2
 comonad
 semigroupoids
 bifunctors

--- a/cabal2pkgbuild.sh
+++ b/cabal2pkgbuild.sh
@@ -28,7 +28,7 @@ pacman_to_cblrepo () {
 	done
 
 	for k in ${(@k)pkgs1}; do
-		package="${k#haskell-},${pkgs1[$k]/-/,}"
+		package="${k#haskell-},${pkgs1[$k]/[_-]/,}"
 		pkgs2+=($package)
 	done
 
@@ -71,8 +71,8 @@ case $mode in
 	(initdb|initdb-sync)
 	rm -fv cblrepo.db
 
-	# Add `ghc` itself
-	ghcversion=$(pacman -Q ghc | cut -d " " -f2 | sed 's/-/,/')
+	# Add `ghc` itself. Always use 0 as xrev for it.
+	ghcversion=$(pacman -Q ghc | cut -d " " -f2 | sed 's/-/,0,/')
 	command="cblrepo add --distro-pkg ghc,$ghcversion"
 	# Tell user what we are going to do.
 	echo $command

--- a/cabal2pkgbuild.sh
+++ b/cabal2pkgbuild.sh
@@ -165,7 +165,7 @@ case $mode in
 	if [[ $mode == initdb-sync ]]; then
 		# Sync cblrepo with Hackage
 		echo -n "Syncing cblrepo with Hackage..."
-		cblrepo sync
+		cblrepo update
 		echo "done"
 	fi
 


### PR DESCRIPTION
- Use x-revision in package names.
- Replace command `cblrepo sync` with `cblrepo update`.
- Drop `aria2` and use `cblrepo extract` since there is no more `cblrepo urls` command.
- Add support for explicit version to be specified for some packages.
